### PR TITLE
fix: integrate Codex UI with DSH Desktop and Archive Manager

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -64,8 +64,26 @@ type ArchiveRegistry = {
   deleteSession: (sessionId: SessionId) => Promise<{ ok: boolean; error?: { message: string } }>
 }
 
+type UiWorkspaceService = {
+  startSession: (workspaceId?: WorkspaceId) => void
+}
+
 function hasDeleteSession(value: unknown): value is ArchiveRegistry {
   return value !== null && typeof value === 'object' && 'deleteSession' in value && typeof value.deleteSession === 'function'
+}
+
+function hasStartSession(value: unknown): value is UiWorkspaceService {
+  return value !== null && typeof value === 'object' && 'startSession' in value && typeof value.startSession === 'function'
+}
+
+/** Archive Manager replaces the official ui-workspace row with this optional service. */
+export function startWorkspaceSession(ctx: ClientContext, workspaceId?: WorkspaceId): void {
+  const uiWorkspace = (ctx.get as (name: string) => unknown)('uiWorkspace')
+  if (hasStartSession(uiWorkspace)) {
+    uiWorkspace.startSession(workspaceId)
+    return
+  }
+  ctx.workspaces.startSession(workspaceId)
 }
 
 /** 替换 DSH 的官方 sidebar 插槽，不修改 DSH 源码或会话数据。 */
@@ -92,7 +110,7 @@ export function apply(ctx: ClientContext): void {
     },
     inject: () => ({
       openSession: (sessionId: SessionId) => { ctx.sessions.open(sessionId) },
-      startSession: (workspaceId?: WorkspaceId) => { ctx.workspaces.startSession(workspaceId) },
+      startSession: (workspaceId?: WorkspaceId) => { startWorkspaceSession(ctx, workspaceId) },
       toggleSidebar: () => { ctx.layout.toggleSidebar() },
       archiveSession: (sessionId: SessionId) => ctx.workspaces.archiveSession(sessionId),
       deleteSession,
@@ -154,7 +172,7 @@ export function apply(ctx: ClientContext): void {
       renameWorkspace: (workspaceId: WorkspaceId, title: string) => ctx.workspaces.rename(workspaceId, title),
       insertWorkspaceBefore: (workspaceId: WorkspaceId, beforeWorkspaceId?: WorkspaceId) => ctx.workspaces.insertBefore(workspaceId, beforeWorkspaceId),
       insertSessionBefore: (workspaceId: WorkspaceId, sessionId: SessionId, beforeSessionId?: SessionId) => ctx.workspaces.insertSessionBefore(workspaceId, sessionId, beforeSessionId),
-      startSession: (workspaceId?: WorkspaceId) => { ctx.workspaces.startSession(workspaceId) },
+      startSession: (workspaceId?: WorkspaceId) => { startWorkspaceSession(ctx, workspaceId) },
     }),
   }, CodexWorkspaceBrowser))
 

--- a/src/dependency-manager.ts
+++ b/src/dependency-manager.ts
@@ -1,7 +1,7 @@
 import { spawn, type ChildProcess } from 'node:child_process'
 import { readFile, unlink, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
-import { resolve, sep } from 'node:path'
+import { basename, dirname, isAbsolute, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { MANAGED_DEPENDENCIES, SUITE_MEMBER_PACKAGES, SUITE_PACKAGE, managedDependency, type ManagedDependencyId } from './dependencies.ts'
 
@@ -20,9 +20,119 @@ export type DependencyStatus = {
   updateAvailable: boolean
 }
 
-function profileDirectory(): string {
-  if (process.env.DSH_PROFILE_DIR !== undefined) return process.env.DSH_PROFILE_DIR
-  return resolve(homedir(), '.dsh', 'profiles', 'web')
+type OptionalServiceContext = {
+  get?: (name: string) => unknown
+}
+
+type DesktopProfilesService = {
+  current?: { name?: unknown; dir?: unknown }
+}
+
+type DesktopPnpmHandle = {
+  stdout?: NodeJS.ReadableStream
+  stderr?: NodeJS.ReadableStream
+  done: Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }>
+  cancel(): void
+}
+
+type DesktopPnpmService = {
+  runPlugin(args: readonly string[], invokingDir: string, signal?: AbortSignal): DesktopPnpmHandle
+}
+
+type DesktopPnpmBootstrap = {
+  activeProfileName?: unknown
+  activeProfileDir?: unknown
+  dshBootstrapPath?: unknown
+}
+
+export type DependencyRuntime = {
+  environmentKind: 'desktop' | 'cli'
+  profileName: string
+  profileDir: string
+  runtimeRoots: readonly string[]
+  desktopPnpm?: DesktopPnpmService
+}
+
+export type DependencyRuntimeOptions = {
+  env?: NodeJS.ProcessEnv
+  argv?: readonly string[]
+  cwd?: string
+  homeDir?: string
+}
+
+function optionalService<T>(ctx: OptionalServiceContext | undefined, name: string): T | undefined {
+  if (ctx === undefined) return undefined
+  return (typeof ctx.get === 'function' ? ctx.get(name) : (ctx as Record<string, unknown>)[name]) as T | undefined
+}
+
+function validProfileName(value: unknown): value is string {
+  return typeof value === 'string' && value !== '' && value !== '.' && value !== '..'
+    && value !== 'node_modules' && !value.includes('/') && !value.includes('\\') && !/[\0-\x1f\x7f]/.test(value)
+}
+
+function profileNameFromArgv(argv: readonly string[]): string | undefined {
+  for (let index = 2; index < argv.length; index += 1) {
+    const argument = argv[index]
+    if (argument === '--profile') return argv[index + 1]
+    if (argument?.startsWith('--profile=')) return argument.slice('--profile='.length)
+  }
+  return argv[2] === 'web' ? 'web' : undefined
+}
+
+/** 从 Desktop CLI bootstrap 向上查找应用内置的 node_modules 根目录。 */
+export function desktopRuntimeRoots(bootstrapPath: string): string[] {
+  if (!isAbsolute(bootstrapPath)) return []
+  const roots: string[] = []
+  let current = dirname(resolve(bootstrapPath))
+  for (let depth = 0; depth < 8; depth += 1) {
+    roots.push(current)
+    const parent = dirname(current)
+    if (parent === current) break
+    current = parent
+  }
+  return roots
+}
+
+/**
+ * Desktop 通过可选 Host service 暴露当前 profile；普通 Web/CLI 继续使用
+ * DSH_PROFILE_DIR、命令行 profile 与默认 web profile。
+ */
+export function resolveDependencyRuntime(ctx?: OptionalServiceContext, options: DependencyRuntimeOptions = {}): DependencyRuntime {
+  const env = options.env ?? process.env
+  const argv = options.argv ?? process.argv
+  const cwd = options.cwd ?? process.cwd()
+  const home = options.homeDir ?? homedir()
+  const profiles = optionalService<DesktopProfilesService>(ctx, 'desktopProfiles')
+  const desktopPnpm = optionalService<DesktopPnpmService>(ctx, 'desktopPnpm')
+  const bootstrap = optionalService<DesktopPnpmBootstrap>(ctx, 'desktopPnpmBootstrap')
+  const current = profiles?.current
+  if (validProfileName(current?.name) && typeof current.dir === 'string' && isAbsolute(current.dir)) {
+    const profileDir = resolve(current.dir)
+    const bootstrapMatches = bootstrap?.activeProfileName === current.name
+      && typeof bootstrap.activeProfileDir === 'string'
+      && resolve(bootstrap.activeProfileDir) === profileDir
+    const runtimeRoots = typeof bootstrap?.dshBootstrapPath === 'string'
+      ? desktopRuntimeRoots(bootstrap.dshBootstrapPath)
+      : []
+    return {
+      environmentKind: 'desktop',
+      profileName: current.name,
+      profileDir,
+      runtimeRoots,
+      ...(bootstrapMatches && typeof desktopPnpm?.runPlugin === 'function' ? { desktopPnpm } : {}),
+    }
+  }
+  const profileDir = resolve(env.DSH_PROFILE_DIR ?? resolve(home, '.dsh', 'profiles', 'web'))
+  const selected = profileNameFromArgv(argv)
+  const profileName = validProfileName(selected) ? selected : validProfileName(basename(profileDir)) ? basename(profileDir) : 'web'
+  const cliRuntimeRoot = argv[1] === undefined ? undefined : resolveDshRuntimeRoot(argv[1], cwd)
+  const runtimeRoots = [env.DSH_RUNTIME_DIR, cliRuntimeRoot]
+    .filter((root): root is string => root !== undefined && root !== '')
+  return { environmentKind: 'cli', profileName, profileDir, runtimeRoots }
+}
+
+function profileDirectory(runtime: DependencyRuntime): string {
+  return runtime.profileDir
 }
 
 type ProfileManifest = {
@@ -31,9 +141,9 @@ type ProfileManifest = {
   dsh?: { profile?: { bundles?: string[] } }
 }
 
-async function declaredPluginNames(): Promise<string[]> {
+async function declaredPluginNames(runtime: DependencyRuntime): Promise<string[]> {
   try {
-    const manifest = JSON.parse(await readFile(resolve(profileDirectory(), 'package.json'), 'utf8')) as ProfileManifest
+    const manifest = JSON.parse(await readFile(resolve(profileDirectory(runtime), 'package.json'), 'utf8')) as ProfileManifest
     return [...new Set([
       ...Object.keys({ ...manifest.devDependencies, ...manifest.dependencies }),
       ...(manifest.dsh?.profile?.bundles ?? []),
@@ -77,14 +187,13 @@ export function resolveDshRuntimeRoot(entry = process.argv[1], cwd = process.cwd
   return root.endsWith(sep) ? root.slice(0, -1) : root
 }
 
-function packageLookupRoots(packageName: string): string[] {
-  if (!isOfficialRuntimePackage(packageName)) return [profileDirectory()]
-  const runtimeDir = process.env.DSH_RUNTIME_DIR
-  return [...new Set([runtimeDir, resolveDshRuntimeRoot(), profileDirectory()].filter((root): root is string => root !== undefined && root !== ''))]
+function packageLookupRoots(packageName: string, runtime: DependencyRuntime): string[] {
+  if (!isOfficialRuntimePackage(packageName)) return [profileDirectory(runtime)]
+  return [...new Set([...runtime.runtimeRoots, profileDirectory(runtime)])]
 }
 
-async function installedPackageVersion(packageName: string): Promise<string | undefined> {
-  for (const root of packageLookupRoots(packageName)) {
+async function installedPackageVersion(packageName: string, runtime: DependencyRuntime): Promise<string | undefined> {
+  for (const root of packageLookupRoots(packageName, runtime)) {
     try {
       const manifest = JSON.parse(await readFile(resolve(root, 'node_modules', ...packageName.split('/'), 'package.json'), 'utf8')) as PackageManifest
       if (typeof manifest.version === 'string' && manifest.version !== '') return manifest.version
@@ -173,9 +282,9 @@ export function applyReleaseExclude(source: string, packageName: string, version
 }
 
 /** 将用户本次确认的精确版本加入 Profile 的 pnpm 发布时间保护例外。 */
-async function ensureLatestReleaseAllowed(packageName: string, version: string): Promise<void> {
+async function ensureLatestReleaseAllowed(packageName: string, version: string, runtime: DependencyRuntime): Promise<void> {
   if (parseSemver(version) === undefined) throw new Error('npm 返回了无法识别的最新版本。')
-  const path = resolve(profileDirectory(), 'pnpm-workspace.yaml')
+  const path = resolve(profileDirectory(runtime), 'pnpm-workspace.yaml')
   let source: string
   try {
     source = await readFile(path, 'utf8')
@@ -228,11 +337,11 @@ export function newerVersion(installed: string, latest: string): boolean {
   return comparePrerelease(candidate.prerelease, current.prerelease) > 0
 }
 
-/** 返回 Web profile 中固定管理插件的实际安装版本与 npm latest 状态。 */
-export async function dependencyStatuses(): Promise<readonly DependencyStatus[]> {
-  const declaredNames = await declaredPluginNames()
+/** 返回当前 profile 中固定管理插件的实际安装版本与 npm latest 状态。 */
+export async function dependencyStatuses(runtime: DependencyRuntime = resolveDependencyRuntime()): Promise<readonly DependencyStatus[]> {
+  const declaredNames = await declaredPluginNames(runtime)
   return Promise.all(MANAGED_DEPENDENCIES.map(async dependency => {
-    const version = await installedPackageVersion(dependency.packageName)
+    const version = await installedPackageVersion(dependency.packageName, runtime)
     const declared = isOfficialRuntimePackage(dependency.packageName) || isManagedPackageDeclared(dependency.packageName, declaredNames)
     if (version === undefined || !isManagedPackageInstalled({ installedVersion: version, declared })) return { ...dependency, installed: false, updateAvailable: false }
     const latestVersion = await npmLatestVersion(dependency.packageName)
@@ -261,8 +370,8 @@ export function isRestartableInstallError(error: unknown): boolean {
   return /完全退出桌面端|正在运行的插件|pnpm 仓库不一致/.test(message)
 }
 
-async function recordPendingUpdate(packageName: string, version: string): Promise<void> {
-  const pendingPath = resolve(profileDirectory(), PROFILE_PENDING_UPDATES_FILE)
+async function recordPendingUpdate(packageName: string, version: string, runtime: DependencyRuntime): Promise<void> {
+  const pendingPath = resolve(profileDirectory(runtime), PROFILE_PENDING_UPDATES_FILE)
   let packages: Array<{ packageName: string; version: string }> = []
   try {
     const parsed = JSON.parse(await readFile(pendingPath, 'utf8')) as { packages?: unknown }
@@ -282,8 +391,8 @@ async function recordPendingUpdate(packageName: string, version: string): Promis
   await writeFile(pendingPath, `${JSON.stringify({ packages }, undefined, 2)}\n`, 'utf8')
 }
 
-async function removePendingUpdate(packageName: string): Promise<void> {
-  const pendingPath = resolve(profileDirectory(), PROFILE_PENDING_UPDATES_FILE)
+async function removePendingUpdate(packageName: string, runtime: DependencyRuntime): Promise<void> {
+  const pendingPath = resolve(profileDirectory(runtime), PROFILE_PENDING_UPDATES_FILE)
   try {
     const parsed = JSON.parse(await readFile(pendingPath, 'utf8')) as { packages?: unknown }
     if (!Array.isArray(parsed.packages)) return
@@ -299,8 +408,8 @@ async function removePendingUpdate(packageName: string): Promise<void> {
   }
 }
 
-async function recordDeclaredVersion(packageName: string, version: string): Promise<void> {
-  const manifestPath = resolve(profileDirectory(), 'package.json')
+async function recordDeclaredVersion(packageName: string, version: string, runtime: DependencyRuntime): Promise<void> {
+  const manifestPath = resolve(profileDirectory(runtime), 'package.json')
   let manifest: { dependencies?: Record<string, string> }
   try {
     manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as { dependencies?: Record<string, string> }
@@ -337,6 +446,7 @@ export function pluginExecArgv(args: readonly string[] = process.execArgv): stri
 }
 
 const activePluginChildren = new Set<ChildProcess>()
+const activeDesktopPluginHandles = new Set<DesktopPnpmHandle>()
 
 function terminatePluginChild(child: ChildProcess): void {
   if (child.exitCode !== null || child.killed) return
@@ -352,6 +462,7 @@ function terminatePluginChild(child: ChildProcess): void {
 /** 插件停用时终止仍在运行的安装进程，避免热更新后遗留 pnpm。 */
 export function disposeDependencyInstaller(): void {
   for (const child of activePluginChildren) terminatePluginChild(child)
+  for (const handle of activeDesktopPluginHandles) handle.cancel()
 }
 
 export function monitorPluginChild(child: ChildProcess, timeoutMs = PLUGIN_INSTALL_TIMEOUT_MS): Promise<void> {
@@ -379,9 +490,41 @@ export function monitorPluginChild(child: ChildProcess, timeoutMs = PLUGIN_INSTA
   })
 }
 
-function runDshPlugin(args: readonly string[], timeoutMs = PLUGIN_INSTALL_TIMEOUT_MS): Promise<void> {
+function monitorDesktopPlugin(handle: DesktopPnpmHandle, timeoutMs = PLUGIN_INSTALL_TIMEOUT_MS): Promise<void> {
+  return new Promise((resolvePromise, reject) => {
+    activeDesktopPluginHandles.add(handle)
+    let output = ''
+    let settled = false
+    const collect = (chunk: Buffer | string): void => { output = `${output}${String(chunk)}`.slice(-64 * 1024) }
+    const finish = (error?: Error): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeout)
+      activeDesktopPluginHandles.delete(handle)
+      error === undefined ? resolvePromise() : reject(error)
+    }
+    handle.stdout?.on('data', collect)
+    handle.stderr?.on('data', collect)
+    handle.stdout?.once('error', () => { handle.cancel(); finish(new Error('无法读取 DSH Desktop 插件安装输出。')) })
+    handle.stderr?.once('error', () => { handle.cancel(); finish(new Error('无法读取 DSH Desktop 插件安装输出。')) })
+    void handle.done.then(
+      outcome => { finish(outcome.exitCode === 0 && outcome.signal === null ? undefined : pluginCommandError(output)) },
+      () => { finish(pluginCommandError(output)) },
+    )
+    const timeout = setTimeout(() => {
+      handle.cancel()
+      finish(new Error('插件安装超时，已终止安装进程。请检查网络后重试。'))
+    }, timeoutMs)
+    timeout.unref?.()
+  })
+}
+
+export function runDshPlugin(args: readonly string[], runtime: DependencyRuntime = resolveDependencyRuntime(), timeoutMs = PLUGIN_INSTALL_TIMEOUT_MS): Promise<void> {
+  if (runtime.desktopPnpm !== undefined) {
+    return monitorDesktopPlugin(runtime.desktopPnpm.runPlugin(args, runtime.profileDir), timeoutMs)
+  }
   const entry = resolveDshCliEntry()
-  const child = spawn(process.execPath, [...pluginExecArgv(), entry, 'plugin', '--profile', 'web', ...args], {
+  const child = spawn(process.execPath, [...pluginExecArgv(), entry, 'plugin', '--profile', runtime.profileName, ...args], {
     cwd: process.cwd(),
     env: { ...process.env, CI: 'true' },
     windowsHide: true,
@@ -394,11 +537,15 @@ function runDshPlugin(args: readonly string[], timeoutMs = PLUGIN_INSTALL_TIMEOU
 let installing = false
 
 /** 仅允许安装固定依赖，避免把浏览器输入转成任意命令。 */
-export async function installDependency(id: string | null, requestHotUpdate: () => boolean = requestDesktopHotUpdate): Promise<readonly DependencyStatus[]> {
+export async function installDependency(
+  id: string | null,
+  requestHotUpdate: () => boolean = requestDesktopHotUpdate,
+  runtime: DependencyRuntime = resolveDependencyRuntime(),
+): Promise<readonly DependencyStatus[]> {
   if (installing) throw new Error('已有依赖安装正在进行，请等待完成后再试。')
   installing = true
   try {
-    return await installDependenciesLocked([id], requestHotUpdate)
+    return await installDependenciesLocked([id], requestHotUpdate, runtime)
   } finally {
     installing = false
   }
@@ -415,27 +562,34 @@ export function updatableDependencyIds(statuses: readonly DependencyStatus[]): M
 }
 
 /** 把所有待更新版本一次写入清单，最后只请求一次桌面热更新。 */
-export async function updateAllDependencies(requestHotUpdate: () => boolean = requestDesktopHotUpdate): Promise<UpdateAllDependenciesResult> {
+export async function updateAllDependencies(
+  requestHotUpdate: () => boolean = requestDesktopHotUpdate,
+  runtime: DependencyRuntime = resolveDependencyRuntime(),
+): Promise<UpdateAllDependenciesResult> {
   if (installing) throw new Error('已有依赖安装正在进行，请等待完成后再试。')
   installing = true
   try {
-    const current = await dependencyStatuses()
+    const current = await dependencyStatuses(runtime)
     const ids = updatableDependencyIds(current)
     if (ids.length === 0) return { dependencies: current, updatedCount: 0 }
-    const dependencies = await installDependenciesLocked(ids, requestHotUpdate)
+    const dependencies = await installDependenciesLocked(ids, requestHotUpdate, runtime)
     return { dependencies, updatedCount: ids.length }
   } finally {
     installing = false
   }
 }
 
-async function installDependenciesLocked(ids: readonly (string | null)[], requestHotUpdate: () => boolean): Promise<readonly DependencyStatus[]> {
+async function installDependenciesLocked(
+  ids: readonly (string | null)[],
+  requestHotUpdate: () => boolean,
+  runtime: DependencyRuntime,
+): Promise<readonly DependencyStatus[]> {
   const dependencies = [...new Set(ids)].map((id) => {
     const dependency = managedDependency(id)
     if (dependency === undefined) throw new Error('不支持安装该依赖。')
     return dependency
   })
-  const declared = await declaredPluginNames()
+  const declared = await declaredPluginNames(runtime)
   const requestedTargets = await Promise.all(dependencies.map(async (dependency) => {
     const latestVersion = await npmLatestVersion(dependency.packageName)
     if (latestVersion === undefined) throw new Error('无法获取 npm 最新版本，请检查网络或 npm registry 后重试。')
@@ -449,28 +603,28 @@ async function installDependenciesLocked(ids: readonly (string | null)[], reques
   const targets = await Promise.all(targetPackages.map(async (packageName) => {
     const requestedVersion = requestedVersions.get(packageName)
     if (requestedVersion !== undefined) return { packageName, version: requestedVersion }
-    const version = await installedPackageVersion(packageName) ?? await npmLatestVersion(packageName)
+    const version = await installedPackageVersion(packageName, runtime) ?? await npmLatestVersion(packageName)
     if (version === undefined) throw new Error('无法读取 Suite 成员版本，请检查 npm 安装后重试。')
     return { packageName, version }
   }))
   const remove = [...new Set(targets.flatMap(target => pluginsToRemoveBeforeInstall(declared, target.packageName)))]
   for (const target of targets) {
-    await ensureLatestReleaseAllowed(target.packageName, target.version)
-    if (!isOfficialRuntimePackage(target.packageName)) await recordDeclaredVersion(target.packageName, target.version)
-    await recordPendingUpdate(target.packageName, target.version)
+    await ensureLatestReleaseAllowed(target.packageName, target.version, runtime)
+    if (!isOfficialRuntimePackage(target.packageName)) await recordDeclaredVersion(target.packageName, target.version, runtime)
+    await recordPendingUpdate(target.packageName, target.version, runtime)
   }
-  if (remove.length > 0) await runDshPlugin(['remove', ...remove])
-  if (requestHotUpdate()) return dependencyStatuses()
+  if (remove.length > 0) await runDshPlugin(['remove', ...remove], runtime)
+  if (runtime.desktopPnpm === undefined && requestHotUpdate()) return dependencyStatuses(runtime)
   for (const target of targets) {
     try {
-      await runDshPlugin(['add', `${target.packageName}@${target.version}`, '--registry=https://registry.npmjs.org/'])
+      await runDshPlugin(['add', `${target.packageName}@${target.version}`, '--registry=https://registry.npmjs.org/'], runtime)
     } catch (error) {
-      if (isRestartableInstallError(error)) return dependencyStatuses()
+      if (isRestartableInstallError(error)) return dependencyStatuses(runtime)
       throw error
     }
-    const installed = await installedPackageVersion(target.packageName)
-    if (installed !== target.version) return dependencyStatuses()
-    await removePendingUpdate(target.packageName)
+    const installed = await installedPackageVersion(target.packageName, runtime)
+    if (installed !== target.version) return dependencyStatuses(runtime)
+    await removePendingUpdate(target.packageName, runtime)
   }
-  return dependencyStatuses()
+  return dependencyStatuses(runtime)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 /** 浏览器客户端插件的 Host 入口；客户端逻辑由 dsh.client 加载。 */
 import type { Context } from '@deepseek-ai/cordis'
-import { dependencyStatuses, disposeDependencyInstaller, installDependency, requestDesktopHotUpdate, updateAllDependencies } from './dependency-manager.ts'
+import { dependencyStatuses, disposeDependencyInstaller, installDependency, requestDesktopHotUpdate, resolveDependencyRuntime, updateAllDependencies } from './dependency-manager.ts'
 import { authorizedExplorerWorkspacePath } from './explorer-path-policy.ts'
 import { hostServices } from './host-services.ts'
 import { ForegroundExplorer } from './native-explorer.ts'
@@ -115,7 +115,7 @@ export function apply(ctx: Context): void {
         const url = new URL(request.url ?? '/', 'http://localhost')
         try {
           if (request.method === 'GET') {
-            const dependencies = await dependencyStatuses()
+            const dependencies = await dependencyStatuses(resolveDependencyRuntime(ctx))
             response.writeHead(200, { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' })
             response.end(JSON.stringify({ dependencies }))
             return
@@ -131,7 +131,7 @@ export function apply(ctx: Context): void {
               const { dependencies, updatedCount } = await updateAllDependencies(() => {
                 restartAfterResponse = typeof process.send === 'function'
                 return restartAfterResponse
-              })
+              }, resolveDependencyRuntime(ctx))
               response.writeHead(200, { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' })
               response.end(JSON.stringify({ dependencies, restartRequired: updatedCount > 0 }))
               if (restartAfterResponse) setTimeout(() => { requestDesktopHotUpdate() }, 150).unref?.()
@@ -141,7 +141,7 @@ export function apply(ctx: Context): void {
             const dependencies = await installDependency(url.searchParams.get('dependency'), () => {
               restartAfterResponse = typeof process.send === 'function'
               return restartAfterResponse
-            })
+            }, resolveDependencyRuntime(ctx))
             response.writeHead(200, { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' })
             response.end(JSON.stringify({ dependencies, restartRequired: true }))
             if (restartAfterResponse) setTimeout(() => { requestDesktopHotUpdate() }, 150).unref?.()

--- a/tests/about-dependencies.assert.ts
+++ b/tests/about-dependencies.assert.ts
@@ -43,6 +43,9 @@ assert.match(manager, /minimumReleaseAgeExclude/, '用户确认更新的精确�
 assert.match(manager, /ensureLatestReleaseAllowed/, '安装与更新前必须持久化本次确认的版本白名单')
 assert.match(manager, /resolveDshCliEntry/, '必须把当前 CLI 入口收成绝对路径后再启动子进程')
 assert.match(manager, /cwd: process\.cwd\(\)/, '子进程必须沿用当前 DSH 启动目录，而不是 dirname\(entry\)')
+assert.match(manager, /desktopProfiles/, 'Desktop 必须通过 Host service 读取当前 profile')
+assert.match(manager, /desktopPnpm/, 'Desktop 安装必须复用 Host 提供的包管理能力')
+assert.doesNotMatch(manager, /'--profile', 'web'/, '安装命令不得把目标 profile 硬编码为 web')
 assert.match(manager, /\['add', `\$\{target\.packageName\}@\$\{target\.version\}`, '--registry=https:\/\/registry\.npmjs\.org\/'\]/, '安装必须走官方 npm 源，避免镜像未同步导致失败')
 assert.match(manager, /pluginsToRemoveBeforeInstall/, '单独更新子插件前必须卸掉套件')
 assert.doesNotMatch(manager, /--config\.minimumReleaseAge=0/, '不得临时关闭整次 pnpm 解析的发布时间保护')
@@ -67,7 +70,7 @@ assert.match(about, /about\.updateAll/, '关于页必须提供全部更新按钮
 assert.match(about, /action=update-all/, '全部更新必须调用批量接口，不能在浏览器逐项请求')
 assert.match(about, /aria-busy/, '批量更新必须提供可访问的忙碌状态')
 assert.match(manager, /updatableDependencyIds/, '批量更新必须只选择已安装且可更新的插件')
-assert.match(manager, /if \(requestHotUpdate\(\)\)/, '批量更新登记完全部版本后只请求一次热更新')
+assert.match(manager, /runtime\.desktopPnpm === undefined && requestHotUpdate\(\)/, '仅旧 Host 在登记完全部版本后请求一次热更新，Desktop 必须先执行宿主安装')
 assert.match(about, /about\.feature\.search/, '关于页必须列出全局搜索能力')
 assert.match(about, /about\.feature\.navigator/, '关于页必须列出会话轮次导航能力')
 assert.match(sidebar, /selectSection\(t\('about\.nav'\)\)/, '缺失依赖的侧栏入口必须跳转关于页面')
@@ -76,4 +79,3 @@ assert.match(locales, /about\.dependency\.im/, '关于页必须提供 IM 插件�
 assert.match(locales, /about\.dependency\.schedule/, '关于页必须提供定时任务插件名称')
 assert.match(locales, /about\.dependency\.market/, '关于页必须提供插件市场名称')
 assert.match(locales, /sidebar\.marketplace/, '插件入口必须认识市场分区标题')
-

--- a/tests/client-runtime.integration.spec.ts
+++ b/tests/client-runtime.integration.spec.ts
@@ -2,7 +2,7 @@ import { createRequire } from 'node:module'
 import { act, createElement, type ReactNode } from 'react'
 import { afterEach, expect, test, vi } from 'vitest'
 import { SlotTestRuntime } from '@deepseek-ai/dsh-client-test-runtime'
-import { apply, inject } from '../src/client/index.ts'
+import { apply, inject, startWorkspaceSession } from '../src/client/index.ts'
 import { CodexSidebar } from '../src/client/CodexSidebar.tsx'
 import { ConnectorsSection } from '../src/client/ConnectorsSection.tsx'
 
@@ -13,6 +13,24 @@ const createRoot = (createRequire(import.meta.url)('react-dom/client') as {
 let runtime: SlotTestRuntime | undefined
 
 afterEach(async () => { await runtime?.dispose() })
+
+test('新建任务优先使用 Archive Manager 提供的 uiWorkspace，并保留官方回退', () => {
+  const archiveStart = vi.fn()
+  const coreStart = vi.fn()
+  const workspaceId = 'workspace-1'
+  startWorkspaceSession({
+    get: (name: string) => name === 'uiWorkspace' ? { startSession: archiveStart } : undefined,
+    workspaces: { startSession: coreStart },
+  } as never, workspaceId as never)
+  expect(archiveStart).toHaveBeenCalledWith(workspaceId)
+  expect(coreStart).not.toHaveBeenCalled()
+
+  startWorkspaceSession({
+    get: () => undefined,
+    workspaces: { startSession: coreStart },
+  } as never, workspaceId as never)
+  expect(coreStart).toHaveBeenCalledWith(workspaceId)
+})
 
 test('侧栏替换以更低优先级接管工作区树，并保留 footer action 子插槽', async () => {
   runtime = await SlotTestRuntime.create()

--- a/tests/dependency-manager.assert.ts
+++ b/tests/dependency-manager.assert.ts
@@ -1,9 +1,12 @@
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'node:events'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import type { ChildProcess } from 'node:child_process'
 import { join, resolve } from 'node:path'
+import { tmpdir } from 'node:os'
+import { PassThrough } from 'node:stream'
 import { pathToFileURL } from 'node:url'
-import { applyReleaseExclude, directPackagesForInstall, isManagedPackageDeclared, isManagedPackageInstalled, isOfficialRuntimePackage, isRestartableInstallError, monitorPluginChild, newerVersion, pluginCommandError, pluginExecArgv, requestDesktopHotUpdate, pluginsToRemoveBeforeInstall, resolveDshPluginTarget, resolveDshCliEntry, resolveDshRuntimeRoot, updatableDependencyIds } from '../src/dependency-manager.ts'
+import { applyReleaseExclude, dependencyStatuses, desktopRuntimeRoots, directPackagesForInstall, isManagedPackageDeclared, isManagedPackageInstalled, isOfficialRuntimePackage, isRestartableInstallError, monitorPluginChild, newerVersion, pluginCommandError, pluginExecArgv, requestDesktopHotUpdate, pluginsToRemoveBeforeInstall, resolveDependencyRuntime, resolveDshPluginTarget, resolveDshCliEntry, resolveDshRuntimeRoot, runDshPlugin, updatableDependencyIds } from '../src/dependency-manager.ts'
 import { crossSiteRequest, publicDependencyError } from '../src/index.ts'
 
 const sourceRoot = resolve('fixtures', 'deepseek-harness')
@@ -36,6 +39,77 @@ assert.equal(
   undefined,
   '源码启动不应误判为全局 DSH 运行时',
 )
+
+const desktopProfileDir = resolve('fixtures', 'desktop-profile')
+const desktopBootstrapPath = resolve('fixtures', 'DSH Desktop.app', 'Contents', 'Resources', 'app.asar.unpacked', 'lib', 'desktop-cli.js')
+let desktopPluginArgs: readonly string[] | undefined
+let desktopPluginCwd: string | undefined
+const desktopPnpm = {
+  runPlugin(args: readonly string[], invokingDir: string) {
+    desktopPluginArgs = args
+    desktopPluginCwd = invokingDir
+    return {
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      done: Promise.resolve({ exitCode: 0, signal: null }),
+      cancel() {},
+    }
+  },
+}
+const desktopServices = new Map<string, unknown>([
+  ['desktopProfiles', { current: { name: 'desktop', dir: desktopProfileDir } }],
+  ['desktopPnpm', desktopPnpm],
+  ['desktopPnpmBootstrap', { activeProfileName: 'desktop', activeProfileDir: desktopProfileDir, dshBootstrapPath: desktopBootstrapPath }],
+])
+const desktopRuntime = resolveDependencyRuntime({ get: name => desktopServices.get(name) }, { env: {}, argv: ['/app'], homeDir: resolve('fixtures', 'home') })
+assert.equal(desktopRuntime.environmentKind, 'desktop')
+assert.equal(desktopRuntime.profileName, 'desktop')
+assert.equal(desktopRuntime.profileDir, desktopProfileDir, 'Desktop 必须读取 Host 当前 profile，而不是回退到 web')
+assert.ok(desktopRuntime.runtimeRoots.includes(resolve(desktopBootstrapPath, '..', '..')), 'Desktop runtime roots 必须包含 app.asar.unpacked')
+assert.equal(desktopRuntime.desktopPnpm, desktopPnpm, 'Desktop 安装必须复用 Host 提供的包管理服务')
+
+const customRuntime = resolveDependencyRuntime(undefined, {
+  env: { DSH_PROFILE_DIR: resolve('fixtures', 'profiles', 'custom') },
+  argv: ['/node', installedEntry, '--profile', 'custom'],
+  homeDir: resolve('fixtures', 'home'),
+})
+assert.equal(customRuntime.environmentKind, 'cli')
+assert.equal(customRuntime.profileName, 'custom')
+assert.equal(customRuntime.profileDir, resolve('fixtures', 'profiles', 'custom'), '普通 Web/CLI 必须继续尊重 DSH_PROFILE_DIR')
+assert.deepEqual(desktopRuntimeRoots('relative/desktop-cli.js'), [], 'Desktop bootstrap 必须是可信绝对路径')
+
+await runDshPlugin(['add', '@michengai/dsh-codex-ui@0.2.92'], desktopRuntime, 1_000)
+assert.deepEqual(desktopPluginArgs, ['add', '@michengai/dsh-codex-ui@0.2.92'])
+assert.equal(desktopPluginCwd, desktopProfileDir, 'Desktop 安装必须以当前 profile 作为调用目录')
+
+const statusRoot = await mkdtemp(join(tmpdir(), 'dcu-desktop-status-'))
+const statusProfile = join(statusRoot, 'profiles', 'desktop')
+const statusRuntimeRoot = join(statusRoot, 'app.asar.unpacked')
+const writeManifest = async (root: string, packageName: string, version: string): Promise<void> => {
+  const directory = join(root, 'node_modules', ...packageName.split('/'))
+  await mkdir(directory, { recursive: true })
+  await writeFile(join(directory, 'package.json'), JSON.stringify({ name: packageName, version }), 'utf8')
+}
+await mkdir(statusProfile, { recursive: true })
+await writeFile(join(statusProfile, 'package.json'), JSON.stringify({ dependencies: { '@michengai/dsh-codex-ui': '0.2.92' } }), 'utf8')
+await writeManifest(statusProfile, '@michengai/dsh-codex-ui', '0.2.92')
+await writeManifest(statusRuntimeRoot, '@deepseek-ai/dsh', '0.1.2-alpha.1')
+const previousFetch = globalThis.fetch
+globalThis.fetch = async input => new Response(JSON.stringify({ version: String(input).includes('@deepseek-ai') ? '0.1.2-alpha.1' : '0.2.92' }))
+try {
+  const statuses = await dependencyStatuses({
+    environmentKind: 'desktop',
+    profileName: 'desktop',
+    profileDir: statusProfile,
+    runtimeRoots: [statusRuntimeRoot],
+  })
+  assert.equal(statuses.find(status => status.id === 'ui')?.installed, true, 'Desktop profile 中已声明且存在的 Codex UI 必须显示已安装')
+  assert.equal(statuses.find(status => status.id === 'dsh')?.installed, true, 'Desktop 应用内置的 DSH runtime 必须显示已安装')
+  assert.equal(statuses.find(status => status.id === 'skills')?.installed, false, '当前 profile 未安装的精确包仍应显示缺失')
+} finally {
+  globalThis.fetch = previousFetch
+  await rm(statusRoot, { recursive: true, force: true })
+}
 
 const source = [
   'packages:',


### PR DESCRIPTION
## 中文

### 问题

在 DSH Desktop 中存在两个相关的配套插件兼容问题：

1. 配套管理页面会把已安装的 Codex UI、Automation、dshmarket 以及应用内置 DSH runtime 显示为“未安装”。
2. 安装 `@michengai/dsh-archive-manager` 后，Codex UI 的“新建任务”按钮不再创建或打开空白会话。

状态误判的原因是依赖管理器在缺少 `DSH_PROFILE_DIR` 时固定读取 `~/.dsh/profiles/web`，安装命令也固定使用 `--profile web`。DSH Desktop 实际通过 Host services 暴露活动 profile 和包管理能力。

新建任务失效的原因是 Archive Manager 会替换官方 `ui-workspace` 行并提供 `uiWorkspace.startSession()`，而 Codex UI 仍固定调用 `ctx.workspaces.startSession()`。

### 修复

- 通过可选的 `desktopProfiles` service 读取当前 Desktop profile。
- 从 `desktopPnpmBootstrap.dshBootstrapPath` 定位应用内置 runtime。
- 通过 `desktopPnpm.runPlugin` 在活动 profile 中安装或更新插件。
- 保留普通 Web/CLI 的 `DSH_PROFILE_DIR`、命令行 `--profile` 和默认 `web` 回退。
- 移除硬编码的 `--profile web`。
- 新建任务优先使用 Archive Manager 提供的 `uiWorkspace.startSession()`；未安装该服务时回退官方 `ctx.workspaces.startSession()`。
- 增加 Desktop profile、内置 runtime、Desktop 包管理、Web/CLI 回退和 Archive Manager 新建会话兼容测试。

### 验证

- TypeScript typecheck 通过
- Vitest：4 个测试文件、15 项测试全部通过
- 断言脚本：28/28 通过
- `tsdown` 构建通过
- DSH Desktop 2.0.4 实机验证：重启后配套插件状态正确，新建任务可进入空白会话

## English

### Problem

Two related companion-plugin compatibility issues occur under DSH Desktop:

1. Companion management can report installed Codex UI, Automation, dshmarket, and the bundled DSH runtime as “Not installed”.
2. After installing `@michengai/dsh-archive-manager`, Codex UI’s “New task” action no longer creates or opens a blank session.

The status issue comes from defaulting to `~/.dsh/profiles/web` when `DSH_PROFILE_DIR` is absent and hard-coding `--profile web`, while DSH Desktop exposes its active profile and package manager through Host services.

The session issue occurs because Archive Manager replaces the official `ui-workspace` row and publishes `uiWorkspace.startSession()`, while Codex UI continued to call `ctx.workspaces.startSession()` directly.

### Fix

- Resolve the active Desktop profile through the optional `desktopProfiles` service.
- Locate the bundled runtime from `desktopPnpmBootstrap.dshBootstrapPath`.
- Install and update through `desktopPnpm.runPlugin` in the active profile.
- Preserve `DSH_PROFILE_DIR`, CLI `--profile`, and default `web` fallbacks for non-Desktop Hosts.
- Remove the hard-coded `web` install target.
- Prefer Archive Manager’s `uiWorkspace.startSession()` for new tasks, with a fallback to the official `ctx.workspaces.startSession()` path.
- Add regression coverage for Desktop profile/runtime detection, package management, Web/CLI fallback, and Archive Manager session creation.

### Validation

- TypeScript typecheck passed
- Vitest: 4 files, 15 tests passed
- Assertion scripts: 28/28 passed
- `tsdown` build passed
- Verified on DSH Desktop 2.0.4: statuses survive restart and New task opens a blank session